### PR TITLE
fix(catalog): Respect spec.acronyms in deriveDisplayName

### DIFF
--- a/docs/.vitepress/lib/adl.ts
+++ b/docs/.vitepress/lib/adl.ts
@@ -44,11 +44,17 @@ export function deriveProvider(agent: CatalogAgent): string | null {
 }
 
 export function deriveDisplayName(agent: CatalogAgent): string {
+  const acronyms = new Map(
+    (agent.spec?.acronyms ?? []).map((a) => [a.toLowerCase(), a]),
+  );
   return agent.metadata.name
     .split("-")
-    .map((part) =>
-      part.length === 0 ? part : part[0].toUpperCase() + part.slice(1),
-    )
+    .map((part) => {
+      if (part.length === 0) return part;
+      const preserved = acronyms.get(part.toLowerCase());
+      if (preserved !== undefined) return preserved;
+      return part[0].toUpperCase() + part.slice(1);
+    })
     .join(" ");
 }
 


### PR DESCRIPTION
## Summary

- The agent card title rendered `n8n-agent` as `N8n Agent` because `deriveDisplayName` split on `-` and force-uppercased the first letter of each segment, ignoring `spec.acronyms`.
- Build a case-insensitive lookup from the agent's acronyms list and substitute the user-supplied casing when a name segment matches. Non-matching segments keep the existing title-case behavior.

### Before / after

| `agent.yaml` | Card title before | Card title after |
| --- | --- | --- |
| `name: n8n-agent`, `acronyms: [n8n]` | `N8n Agent` | `n8n Agent` |
| `name: n8n-agent`, `acronyms: [N8N]` | `N8n Agent` | `N8N Agent` |
| `name: postgresql-driver`, `acronyms: [PostgreSQL]` | `Postgresql Driver` | `PostgreSQL Driver` |
| `name: weather-agent`, no acronyms | `Weather Agent` | `Weather Agent` (unchanged) |

Pairs with [inference-gateway/adl-cli#160](https://github.com/inference-gateway/adl-cli/pull/160), which applies the same convention to the generated README title.

## Test plan

- [x] `npm run build` in `docs/` passes
- [ ] Verify the catalog card for `n8n-agent` renders as `n8n Agent` once the site rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)