### PR TITLE
docs(skills): Rewrite list-a-skill how-to for skills.yaml indexer

### DIFF
--- a/docs/.vitepress/components/SkillsBrowser.vue
+++ b/docs/.vitepress/components/SkillsBrowser.vue
@@ -3,12 +3,25 @@ import { computed, onMounted, ref } from "vue";
 import type { Skill } from "../lib/types";
 import { loadSkills } from "../lib/skillService";
 import SkillCard from "./SkillCard.vue";
+import AddEntryDialog from "./AddEntryDialog.vue";
 
 const skills = ref<Skill[]>([]);
 const loading = ref(true);
 const loadError = ref<string | null>(null);
 const searchTerm = ref("");
 const selectedVendor = ref("");
+const showAddDialog = ref(false);
+
+const skillSnippet = `  - url: https://github.com/<owner>/<repo>
+    ref: v1.0.0
+    path: SKILL.md
+    vendor: <your-org-or-handle>
+    license: Apache-2.0
+    tags:
+      - <tag>
+    categories:
+      - developer-tools
+`;
 
 async function fetchSkills() {
   loading.value = true;
@@ -89,6 +102,14 @@ function clearFilters() {
             {{ vendor }}
           </option>
         </select>
+        <button
+          type="button"
+          class="reg-browser__add"
+          @click="showAddDialog = true"
+        >
+          <span class="reg-browser__add-icon" aria-hidden="true">+</span>
+          Add skill
+        </button>
       </div>
 
       <div class="reg-browser__meta">
@@ -135,14 +156,26 @@ function clearFilters() {
           target="_blank"
           rel="noopener noreferrer"
           ><code>catalog.json</code></a
-        >. To submit a skill, open a PR against
+        >. To list a new skill, open a PR against
         <a
           href="https://github.com/inference-gateway/skills"
           target="_blank"
           rel="noopener noreferrer"
           >inference-gateway/skills</a
-        >.
+        >
+        with one entry appended to <code>skills.yaml</code> pointing at any
+        public repo that ships a <code>SKILL.md</code>.
       </div>
+
+      <AddEntryDialog
+        v-model:open="showAddDialog"
+        title="List a new skill"
+        filename="skills.yaml"
+        instructions="Append this entry to the end of skills.yaml in inference-gateway/skills, then replace the placeholders with values for your skill. The repo must ship a SKILL.md with valid Agent Skills frontmatter. GitHub will fork the repo and open a pull request for you."
+        :snippet="skillSnippet"
+        snippet-lang="yaml"
+        edit-url="https://github.com/inference-gateway/skills/edit/main/skills.yaml"
+      />
     </section>
   </ClientOnly>
 </template>

--- a/docs/how-to/list-a-skill.md
+++ b/docs/how-to/list-a-skill.md
@@ -1,70 +1,142 @@
 # List a Skill
 
-Skills are portable markdown playbooks. The skills catalog is
-hand-maintained in [`inference-gateway/skills`](https://github.com/inference-gateway/skills),
-not auto-generated from upstream repos - so adding one means editing
-`catalog.json` directly.
+Skills are portable markdown playbooks - an
+[Agent Skills](https://github.com/anthropics/skills/tree/main/spec) `SKILL.md`
+that an agent reads on demand. Any public GitHub repo that ships one can be
+listed in the catalog. Adding it is a one-PR change against `skills.yaml`.
 
-## Two paths
+For listing an A2A agent instead, see
+[List an Agent](/how-to/list-an-agent).
 
-You can host a skill in two places:
+## Prerequisite: a public repo with a `SKILL.md`
 
-1. **In-repo skill** - drop a `skills/<name>/SKILL.md` into
-   `inference-gateway/skills` and add a `catalog.json` entry whose
-   `source` points at that folder.
-2. **External skill** - host the `SKILL.md` in your own repo and add only
-   a `catalog.json` entry whose `source` points at the external GitHub
-   URL.
+The catalog aggregator pulls each `SKILL.md` from your repo at the pinned
+ref. It must:
 
-Both render identically on `/skills/`.
-
-## The catalog entry shape
-
-Append an object to the `skills` array in
-[`catalog.json`](https://github.com/inference-gateway/skills/blob/main/catalog.json):
-
-```json
-{
-  "name": "skill-creator",
-  "description": "Author a new Agent Skill from a minimal SKILL.md template.",
-  "source": "https://github.com/inference-gateway/skills/tree/main/skills/skill-creator",
-  "vendor": "inference-gateway",
-  "license": "Apache-2.0",
-  "tags": ["meta", "skills", "authoring"],
-  "categories": ["developer-tools"],
-  "homepage": "https://github.com/inference-gateway/skills"
-}
-```
-
-Per field:
-
-- `name` - lowercase kebab-case (`^[a-z0-9-]+$`). For in-repo skills the
-  folder name under `skills/` must match this exactly.
-- `description` - one sentence: what the skill does and when to invoke
-  it. The agent runtime decides whether to surface the skill from this
-  string alone, so vague descriptions get skipped.
-- `source` - canonical URL where `SKILL.md` lives.
-- `vendor` - the maintaining org or person; feeds the vendor filter on
-  `/skills/`.
-- `license` - an SPDX identifier from the
+- Be reachable at a known path under the repo (`SKILL.md` at root, or a
+  nested path like `skills/<name>/SKILL.md` for multi-skill repos).
+- Carry valid frontmatter: `name` (matching `^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
+  and `description` (1-1024 chars). The description alone has to let an
+  agent decide whether to invoke the skill, so vague descriptions get
+  filtered out at runtime.
+- Declare a `license` in the frontmatter, or carry one in the `skills.yaml`
+  entry. Must be an SPDX identifier from the
   [ADL Skill enum](https://github.com/inference-gateway/adl): `MIT`,
   `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `GPL-2.0`, `GPL-3.0`,
   `LGPL-2.1`, `LGPL-3.0`, `MPL-2.0`, `ISC`, `CC0-1.0`, `CC-BY-4.0`,
   `CC-BY-SA-4.0`, `Unlicense`, or `Proprietary`.
-- `tags` - free-form discoverability strings.
-- `categories` - higher-level grouping (e.g. `developer-tools`).
-- `homepage` - optional landing URL beyond the source repo.
 
-## `SKILL.md` frontmatter (in-repo skills)
+The `skill-creator` skill in
+[`inference-gateway/skills`](https://github.com/inference-gateway/skills/tree/main/skills/skill-creator)
+is itself a worked example for authoring a compliant `SKILL.md` - copy it as
+a starting point.
 
-The body is markdown the agent runtime reads on demand. The frontmatter
-declares the same `name` + `description` so the runtime can pick the
-right skill without reading the body:
+## Use the "+ Add skill" button
+
+The fastest path is the **+ Add skill** button on the [Skills](/skills/)
+page. It opens a dialog with a copy-paste snippet and a "Continue to GitHub"
+link that lands you at
+`https://github.com/inference-gateway/skills/edit/main/skills.yaml`. GitHub
+will fork the repo and open the PR for you - paste the entry, fill in the
+fields for your skill, commit, and submit.
+
+## The entry shape
+
+`skills.yaml` is a flat list. Each entry carries the fields the build job
+cannot derive from `SKILL.md` frontmatter alone:
+
+```yaml
+- url: https://github.com/<owner>/<repo>
+  ref: v1.0.0
+  path: SKILL.md
+  vendor: <your-org-or-handle>
+  license: Apache-2.0
+  tags:
+    - <tag>
+  categories:
+    - developer-tools
+  homepage: https://<optional-project-url>
+```
+
+Per field:
+
+- `url` (**required**) - `https://github.com/<owner>/<repo>` URL of the repo
+  that hosts the `SKILL.md`.
+- `ref` (optional) - branch, tag, or commit SHA. Defaults to `main`. Pinning
+  a release tag is strongly recommended for third-party skills so a breaking
+  change upstream cannot silently invalidate the catalog. Ignored for
+  entries pointing at `inference-gateway/skills` itself (the working tree is
+  always the source of truth).
+- `path` (optional) - path to `SKILL.md` within the repo. Defaults to
+  `SKILL.md`. Required for multi-skill repos.
+- `vendor` (**required**) - org or handle shown in the registry UI; feeds
+  the vendor filter on `/skills/`.
+- `license` (optional) - SPDX identifier from the ADL Skill enum (see list
+  above). Falls back to `SKILL.md` frontmatter `license:` if omitted.
+- `tags` (**required**) - free-form discoverability strings.
+- `categories` (**required**) - higher-level grouping (e.g. `developer-tools`).
+- `homepage` (optional) - landing URL beyond the source repo.
+
+The build script reads `name` and `description` from the upstream
+`SKILL.md` frontmatter - they are not duplicated in `skills.yaml`.
+
+## What happens after merge
+
+The [`build-catalog.yml`](https://github.com/inference-gateway/skills/blob/main/.github/workflows/build-catalog.yml)
+workflow in `inference-gateway/skills` runs on every push that touches
+`skills.yaml`, `skills/**`, or the build script; on a daily cron at
+`0 4 * * *` UTC; and on `workflow_dispatch`. It:
+
+1. Fetches `SKILL.md` from each repo at the listed ref (or reads from the
+   local working tree for self-hosted entries).
+2. Parses and validates frontmatter (`name`, `description`, optional
+   `license`).
+3. Rejects duplicate `name` collisions across local and external entries.
+4. Validates `license` is in the ADL Skill enum.
+5. Sorts entries and writes `catalog.json`.
+6. Opens a follow-up PR (`chore(catalog): Rebuild catalog.json`) for a
+   maintainer to merge.
+
+Once that rebuild PR lands on `main`, the jsDelivr `@main` cache window
+bounds visibility - your entry typically appears here within a few hours,
+at most ~12.
+
+If any fetch, parse, frontmatter, license, or dedupe check fails, the
+workflow aborts before writing `catalog.json` - it never publishes a partial
+catalog.
+
+## Optional: host the `SKILL.md` body in `inference-gateway/skills`
+
+Skills the Inference Gateway team maintains directly can live in the
+catalog repo itself, under `skills/<name>/SKILL.md`. The `skills.yaml`
+entry then points `url` back at
+`https://github.com/inference-gateway/skills` and sets `path` to the
+in-repo location:
+
+```yaml
+- url: https://github.com/inference-gateway/skills
+  path: skills/<name>/SKILL.md
+  vendor: inference-gateway
+  license: Apache-2.0
+  tags:
+    - <tag>
+  categories:
+    - developer-tools
+  homepage: https://github.com/inference-gateway/skills
+```
+
+The folder name under `skills/` must match the `SKILL.md` frontmatter
+`name:` exactly. The build script reads `path` from the local working tree
+in this case, so PRs that add a new in-repo skill build correctly before
+the branch is merged to `main`.
+
+`SKILL.md` frontmatter for an in-repo skill:
 
 ```markdown
 ---
 name: <skill-name>
 description: <one sentence: what it does, when to use it>
+license: Apache-2.0
 ---
 
 # <Skill Title>
@@ -72,24 +144,14 @@ description: <one sentence: what it does, when to use it>
 Use this skill when <trigger>.
 ```
 
-The folder name must equal the `name` field. The fully-worked example to
-copy from is
-[`skills/skill-creator/`](https://github.com/inference-gateway/skills/tree/main/skills/skill-creator)
-in the upstream repo - it is itself a skill for authoring skills.
+This is the same shape the build job expects for external skills - the only
+difference is where the file lives.
 
-## Submit a PR
+## Conventions
 
-There is no "+ Add skill" button on `/skills/` yet, so hand-edit
-`catalog.json` and open a PR against
-[`inference-gateway/skills`](https://github.com/inference-gateway/skills).
-The repo uses conventional commits and semantic-release; a subject like
-`feat(catalog): Add foo-skill` is the expected style.
-
-Do **not** hand-edit `CHANGELOG.md` or bump the `release` field in
-`catalog.json` - semantic-release does both on merge to `main`.
-
-## What happens after merge
-
-Unlike the agents catalog, there is no rebuild step - `catalog.json` is
-the source of truth. Visibility is bounded only by the jsDelivr `@main`
-cache window (up to ~12 hours).
+- Conventional commits, capitalized subject -
+  `feat(catalog): Add foo-skill` is the expected style. Semantic-release in
+  the skills repo reads these to compute versions.
+- Do **not** hand-edit `catalog.json`, `CHANGELOG.md`, or the `release` /
+  `updated` fields - all three are regenerated (the catalog by the build
+  workflow, the rest by semantic-release).

--- a/docs/how-to/list-an-agent.md
+++ b/docs/how-to/list-an-agent.md
@@ -3,6 +3,9 @@
 Any public GitHub repo that ships an ADL `agent.yaml` at its root can be
 listed in the catalog. Adding it is a one-line PR.
 
+For listing a portable skill instead, see
+[List a Skill](/how-to/list-a-skill).
+
 ## Prerequisite: a public repo with `agent.yaml` at root
 
 The catalog aggregator pulls `agent.yaml` directly from your repo. It


### PR DESCRIPTION
Closes #16.

## Summary

- Rewrite `docs/how-to/list-a-skill.md` to mirror `list-an-agent.md` now that `inference-gateway/skills# 4` has shipped: `skills.yaml` is the source of truth and `catalog.json` is generated, not hand-edited.
- Add a "+ Add skill" button to `SkillsBrowser.vue`, wired to the shared `AddEntryDialog` with a `skills.yaml`-shaped snippet and a `Continue to GitHub` link pointing at `github.com/inference-gateway/skills/edit/main/skills.yaml`.
- Cross-link `list-an-agent` ↔ `list-a-skill`.

## Test plan

- [ ] `cd docs && npm install && npm run build` succeeds
- [ ] `task lint` / `task format:check` pass
- [ ] `npm run dev`: /skills/ renders the "+ Add skill" button next to the vendor filter; clicking opens the dialog, Copy works, "Continue to GitHub" lands on `skills/edit/main/skills.yaml`.
- [ ] `/how-to/list-a-skill` & `/how-to/list-an-agent` render cleanly and cross-link.

Generated with [Claude Code](https://claude.ai/code)