### PR TITLE
fix: read catalogs from jsDelivr @latest instead of @main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ catalog repo on the CDN**. There is no agent or skill metadata in this repo.
   `inference-gateway/agents`, which keeps an `agents.yaml` list of repo URLs +
   refs and runs a build job (push + daily cron) to fetch, validate, and bundle
   them into `catalog.json`. The site fetches that at runtime via
-  `https://cdn.jsdelivr.net/gh/inference-gateway/agents@main/catalog.json`
+  `https://cdn.jsdelivr.net/gh/inference-gateway/agents@latest/catalog.json`
   (override with `VITE_AGENTS_CATALOG_URL`).
 - **Types are generated**, not hand-written. `docs/.vitepress/types/adl.ts` is
   produced by `docs/scripts/codegen-adl.mjs` from the ADL JSON Schema. Run
@@ -79,7 +79,7 @@ catalog repo on the CDN**. There is no agent or skill metadata in this repo.
 ### Skills: runtime, external
 
 - Fetched at runtime from
-  `https://cdn.jsdelivr.net/gh/inference-gateway/skills@main/catalog.json`
+  `https://cdn.jsdelivr.net/gh/inference-gateway/skills@latest/catalog.json`
   (override with `VITE_SKILLS_CATALOG_URL`). The skills catalog lives in a
   **separate repo** (`inference-gateway/skills`).
 - `docs/.vitepress/lib/skillService.ts` memoizes the fetch the same way as

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ portable skills. Both catalogs are fetched at runtime from sibling repos via
 jsDelivr, so adding or updating an entry doesn't require redeploying this site:
 
 - **Agents catalog**: [`inference-gateway/agents`](https://github.com/inference-gateway/agents)
-  -> `https://cdn.jsdelivr.net/gh/inference-gateway/agents@main/catalog.json`
+  -> `https://cdn.jsdelivr.net/gh/inference-gateway/agents@latest/catalog.json`
 - **Skills catalog**: [`inference-gateway/skills`](https://github.com/inference-gateway/skills)
-  -> `https://cdn.jsdelivr.net/gh/inference-gateway/skills@main/catalog.json`
+  -> `https://cdn.jsdelivr.net/gh/inference-gateway/skills@latest/catalog.json`
 
 Override the catalog URLs locally with `VITE_AGENTS_CATALOG_URL` /
 `VITE_SKILLS_CATALOG_URL` (the Vite env vars exposed by VitePress).

--- a/docs/.vitepress/components/AgentsBrowser.vue
+++ b/docs/.vitepress/components/AgentsBrowser.vue
@@ -155,7 +155,7 @@ function clearFilters() {
       <div class="reg-browser__footer">
         The full catalog is also served as JSON at
         <a
-          href="https://cdn.jsdelivr.net/gh/inference-gateway/agents@main/catalog.json"
+          href="https://cdn.jsdelivr.net/gh/inference-gateway/agents@latest/catalog.json"
           target="_blank"
           rel="noopener noreferrer"
           ><code>catalog.json</code></a

--- a/docs/.vitepress/components/SkillsBrowser.vue
+++ b/docs/.vitepress/components/SkillsBrowser.vue
@@ -152,7 +152,7 @@ function clearFilters() {
       <div class="reg-browser__footer">
         The full catalog is also served as JSON at
         <a
-          href="https://cdn.jsdelivr.net/gh/inference-gateway/skills@main/catalog.json"
+          href="https://cdn.jsdelivr.net/gh/inference-gateway/skills@latest/catalog.json"
           target="_blank"
           rel="noopener noreferrer"
           ><code>catalog.json</code></a

--- a/docs/.vitepress/lib/agentService.ts
+++ b/docs/.vitepress/lib/agentService.ts
@@ -2,7 +2,7 @@ import type { Catalog, CatalogAgent } from "./types";
 
 const CATALOG_URL =
   import.meta.env.VITE_AGENTS_CATALOG_URL ??
-  "https://cdn.jsdelivr.net/gh/inference-gateway/agents@main/catalog.json";
+  "https://cdn.jsdelivr.net/gh/inference-gateway/agents@latest/catalog.json";
 
 let cached: Promise<CatalogAgent[]> | null = null;
 

--- a/docs/.vitepress/lib/skillService.ts
+++ b/docs/.vitepress/lib/skillService.ts
@@ -2,7 +2,7 @@ import type { Skill, SkillCatalog } from "./types";
 
 const CATALOG_URL =
   import.meta.env.VITE_SKILLS_CATALOG_URL ??
-  "https://cdn.jsdelivr.net/gh/inference-gateway/skills@main/catalog.json";
+  "https://cdn.jsdelivr.net/gh/inference-gateway/skills@latest/catalog.json";
 
 let cached: Promise<Skill[]> | null = null;
 

--- a/docs/how-to/browse-and-install.md
+++ b/docs/how-to/browse-and-install.md
@@ -68,8 +68,8 @@ Card fields map directly to the underlying schema:
 Both catalogs are fetched at runtime - this site is just a static
 front-end:
 
-- Agents: `https://cdn.jsdelivr.net/gh/inference-gateway/agents@main/catalog.json`
-- Skills: `https://cdn.jsdelivr.net/gh/inference-gateway/skills@main/catalog.json`
+- Agents: `https://cdn.jsdelivr.net/gh/inference-gateway/agents@latest/catalog.json`
+- Skills: `https://cdn.jsdelivr.net/gh/inference-gateway/skills@latest/catalog.json`
 
 The `@main` ref is cached by jsDelivr for up to ~12 hours, so a freshly
 merged entry may not appear here immediately. For local development you


### PR DESCRIPTION
## Problem

Both `skillService.ts` and `agentService.ts` fetch from jsDelivr's `@main`
branch URL, cached `s-maxage=43200` (12h edge) / `max-age=604800` (7d browser).

This is why the language logos added in inference-gateway/skills#86 never showed
up on the skills page. The build and the UI were both correct — `main` had the
`logo` fields, `SkillCard` already renders them — but jsDelivr was serving a
pre-#86 copy.

## Purging doesn't fix it

Five consecutive purges of the `@main` path, verified against
`raw.githubusercontent`, never converged:

```
attempt 1: cdn=dbfb5ee7fff9 want=a11cf75fd8e0, retrying
attempt 2: cdn=dbfb5ee7fff9 want=a11cf75fd8e0, retrying
attempt 3: cdn=dbfb5ee7fff9 want=a11cf75fd8e0, retrying
```

jsDelivr's origin layer holds the branch snapshot and re-poisons the edge after
each purge — purging the file never resets the `@main` → commit resolution.

## Fix

Use `@latest`, which jsDelivr resolves from the newest git tag:

- nothing to hand-maintain — the version bumps itself
- tagged files are immutable, so they cannot go stale
- matches how the catalogs are already versioned (consumers pin to a catalog
  version, not a branch)

Verified byte-identical to `main` and stable across repeated cache-busted fetches:

```
skills @latest -> x-jsd-version: 0.7.0, 3 logos, 3/3 tries
agents @latest -> x-jsd-version: 0.1.2, HTTP 200
```

Applied to both services, both browser footers, and the docs that quote the URL.

## Companion

inference-gateway/skills#89 adds a workflow that purges the `@latest` alias on
tag push and verifies `x-jsd-version` matches, so a new release shows up promptly.

## Trade-off

The page now tracks released catalog versions rather than `main`. Entries merged
between releases won't appear until the next release — which is the documented
intent, but flagging it since it is a behaviour change.